### PR TITLE
Fix a typo in glorytun-udp-run

### DIFF
--- a/glorytun-udp-run
+++ b/glorytun-udp-run
@@ -12,7 +12,7 @@ fi
 DEV="gt${HOST:+c}-udp-$(basename "$1")"
 
 exec glorytun \
-	bin $BIND $BIND_PORT
+	bind $BIND $BIND_PORT
 	${DEV:+dev "$DEV"} \
 	${HOST:+to "$HOST" "$PORT"} \
 	${OPTIONS:+$OPTIONS}


### PR DESCRIPTION
This could help for Ysurac/openmptcprouter#37.

Signed-off-by: Adrien Gallouët <adrien@gallouet.fr>