### PR TITLE
insert arch=amd64

### DIFF
--- a/debian9-x86_64-bin.sh
+++ b/debian9-x86_64-bin.sh
@@ -23,7 +23,7 @@ fi
 apt-get update
 apt-get -y install apt-transport-https
 
-echo 'deb https://repo.openmptcprouter.com stretch main' > /etc/apt/sources.list.d/openmptcprouter.list
+echo 'deb [arch=amd64] https://repo.openmptcprouter.com stretch main' > /etc/apt/sources.list.d/openmptcprouter.list
 cat <<EOF | tee /etc/apt/preferences.d/openmptcprouter.pref
 Explanation: Prefer OpenMPTCProuter provided packages over the Debian native ones
 Package: *
@@ -31,7 +31,7 @@ Pin: origin repo.openmptcprouter.com
 Pin-Priority: 1001
 EOF
 
-echo 'deb http://deb.debian.org/debian stretch-backports main' > /etc/apt/sources.list.d/stretch-backports.list
+echo 'deb [arch=amd64] http://deb.debian.org/debian stretch-backports main' > /etc/apt/sources.list.d/stretch-backports.list
 wget -O - http://repo.openmptcprouter.com/openmptcprouter.gpg.key | apt-key add -
 apt-get update
 apt-get -y install dirmngr patch rename curl


### PR DESCRIPTION
the script without these changes fails to retrieve the MPTCP kernel as only amd64 is now supported