### PR TITLE
bug fix in the _lan_route procedure

### DIFF
--- a/omr-service
+++ b/omr-service
@@ -54,7 +54,8 @@ _lan_route() {
 		if [ -n "$vpnremoteip" ] && [ "$vpnremoteip" != "null" ]; then
 			echo "$c" | jq -c '.lanips //empty' | 
 			while IFS=$"\n" read -r d; do
-				network=$(ipcalc -n $d | grep Network | awk '{print $2}')
+				subnet=$(sed 's/\[//g; s/\]//g; s/"//g' <<< $d) 
+				network=$(ipcalc -n $subnet | grep Network | awk '{print $2}')
 				[ -n "$network" ] && [ -z "$(ip r show $network via $vpnremoteip)" ] && ip r replace $network via $vpnremoteip 2>&1 >/dev/null
 			done
 		fi


### PR DESCRIPTION
The procedure has an error whilst trying to pickup the subnets from the omr-admin-config.json therefore everytime the procedure starts it was creating the same route to 192.168.1.1 regardless of what data was taken from the config file. I added a sed command to clean the variable from the original value ["192.168.3.1/255.255.255.0"] -to the correct value accepted by the command ipcalc -n 92.168.3.1/255.255.255.0